### PR TITLE
reentry 1.2.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,12 @@ environment:
     - CONFIG: win_python2.7
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
+    - CONFIG: win_python3.6
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_python3.7
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -11,7 +11,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'
 zip_keys:
 - - channel_sources
   - channel_targets

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -11,7 +11,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.7'
 zip_keys:
 - - channel_sources
   - channel_targets

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -1,3 +1,5 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 build_number_decrement:
 - '0'
 channel_sources:
@@ -5,15 +7,18 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'
 zip_keys:
 - - channel_sources
   - channel_targets
-  - docker_image
   - build_number_decrement

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -1,3 +1,5 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 build_number_decrement:
 - '0'
 channel_sources:
@@ -5,15 +7,18 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.7'
 zip_keys:
 - - channel_sources
   - channel_targets
-  - docker_image
   - build_number_decrement

--- a/.ci_support/win_python3.6.yaml
+++ b/.ci_support/win_python3.6.yaml
@@ -1,0 +1,10 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/win_python3.7.yaml
+++ b/.ci_support/win_python3.7.yaml
@@ -1,0 +1,10 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,45 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
+  build_linux_python3.6:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_python3.6"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_python3.7:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_python3.7"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
 
 workflows:
   version: 2
   build_and_test:
     jobs:
       - build_linux_python2.7
+      - build_linux_python3.6
+      - build_linux_python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ osx_image: xcode6.4
 env:
   matrix:
     - CONFIG=osx_python2.7
+    - CONFIG=osx_python3.6
+    - CONFIG=osx_python3.7
 
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/recipe/.circleci/checkout_merge_commit.sh
+++ b/recipe/.circleci/checkout_merge_commit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+
+# Update PR refs for testing.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/head:pr/${CIRCLE_PR_NUMBER}/head"
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Retrieve the refs.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git fetch -u origin ${FETCH_REFS}
+fi
+
+# Checkout the PR merge ref.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Check for merge conflicts.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git branch --merged | grep "pr/${CIRCLE_PR_NUMBER}/head" > /dev/null
+fi

--- a/recipe/.gitattributes
+++ b/recipe/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+*.patch binary
+*.diff binary
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/recipe/.github/CONTRIBUTING.md
+++ b/recipe/.github/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+Thanks for your interest in helping out conda-forge.
+
+Whether you are brand new or a seasoned maintainer, we always appreciate
+feedback from the community about how we can improve conda-forge. If you
+are submitting a PR or issue, please fill out the respective template. Should
+any questions arise please feel free to ask the maintainer team of the
+respective feedstock or reach out to `@conda-forge/core` for more complex
+issues.
+
+In the case of any issues reported, please be sure to demonstrate the relevant
+issue (even if it is an absence of a feature). Providing this information will
+help busy maintainers understand what it is you hope to accomplish. Also this
+will help provide them clues as to what might be going wrong. These examples
+can also be reused as tests in the build to ensure further packages meet these
+criteria. This is requested to help you get timely and relevant feedback. :)

--- a/recipe/.github/ISSUE_TEMPLATE.md
+++ b/recipe/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Thanks for reporting your issue.
+Please fill out the sections below.
+-->
+Issue:
+
+<br/>
+Environment (<code>conda list</code>):
+<details>
+
+```
+$ conda list
+
+```
+</details>
+
+<br/>
+Details about  <code>conda</code> and system ( <code>conda info</code> ):
+<details>
+
+```
+$ conda info
+
+```
+</details>

--- a/recipe/.github/PULL_REQUEST_TEMPLATE.md
+++ b/recipe/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+Thank you for pull request.
+Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
+-->
+Checklist
+* [ ] Used a fork of the feedstock to propose changes
+* [ ] Bumped the build number (if the version is unchanged)
+* [ ] Reset the build number to `0` (if the version changed)
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
+* [ ] Ensured the license file is being packaged.
+
+<!--
+Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
+-->
+
+<!--
+Please add any other relevant info below:
+-->

--- a/recipe/.gitignore
+++ b/recipe/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+
+build_artifacts

--- a/recipe/LICENSE.txt
+++ b/recipe/LICENSE.txt
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) 2015-2018, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "reentry" %}
-{% set version = "1.1.2" %}
-{% set sha256 = "e8b8f250f5dd07a90a5bfa7b0bb854f34c70a8a96ce9b61a55957739a5561e59" %}
+{% set version = "1.2.2" %}
+{% set sha256 = "9c8378965336a1e88b686f0163484dbe5e47815a15ff8a12844d7173877dc6e3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  fn: v{{ version }}.tar.gz
+  url: https://github.com/DropD/reentry/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -16,7 +16,6 @@ build:
   entry_points:
     - reentry = reentry.cli:reentry
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
-  skip: True  # [not py27]
 
 requirements:
   host:
@@ -45,3 +44,4 @@ about:
 extra:
   recipe-maintainers:
     - ltalirz
+    - DropD

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - python
     - click
     - six
-    - py
+    - pathlib2  # [py < 35]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1000
+  number: 0
   entry_points:
     - reentry = reentry.cli:reentry
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"


### PR DESCRIPTION
intermediate versions were broken on conda due to problems with
too long filenames (deep nesting of directories in conda build)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
